### PR TITLE
fix(generator): trim group name for CompositeResourceDefinitions

### DIFF
--- a/generator/main.libsonnet
+++ b/generator/main.libsonnet
@@ -62,9 +62,9 @@ local mergeDocstring(group, version, name, obj, help='') =
 local compositions =
   std.foldl(
     function(acc, def)
-      local render = crdsonnet.xrd.render(def.definition, 'grafana.crossplane.io', processor);
+      local render = crdsonnet.xrd.render(def.definition, 'grafana.net', processor);
 
-      local group = helpers.getGroupKey(def.definition.spec.group, 'grafana.crossplane.io');
+      local group = helpers.getGroupKey(def.definition.spec.group, 'grafana.net');
       local version = 'v1alpha1';
       local kind = helpers.camelCaseKind(crdsonnet.xrd.getKind(def.definition));
 

--- a/generator/namespaced.libsonnet
+++ b/generator/namespaced.libsonnet
@@ -6,4 +6,28 @@ local crds =
     std.parseYaml(importstr './crds.yaml'),
   );
 
-std.map(cngen.fromCRD, crds)
+// XRD metadata.name consists of `plural+group`, for some resources this became longer than 63 characters, which resulted in this error:
+//   'cannot establish control of object: Composition.apiextensions.crossplane.io "stackserviceaccounttoken-namespaced" is invalid: metadata.labels: Invalid value:"xstackserviceaccounttokens.cloud.grafana.crossplane.io.namespaced": must be no more than 63 characters'
+local renameGroup(obj) =
+  assert std.trace(std.manifestJson(obj.definition.metadata), true);
+  local name = std.strReplace(obj.definition.metadata.name, 'crossplane.io', 'net');
+  assert std.length(name) <= 63 : 'CompositeResourceDefinition names must be no more than 63 characters';
+  obj + {
+    definition+: {
+      metadata+: {
+        name: name,
+      },
+      spec+: {
+        group: std.strReplace(super.group, 'crossplane.io', 'net'),
+      },
+    },
+  };
+
+std.foldr(
+  std.map,
+  [
+    renameGroup,
+    cngen.fromCRD,
+  ],
+  crds,
+)

--- a/grafanaplane/alerting/v1alpha1/contactPoint/main.libsonnet
+++ b/grafanaplane/alerting/v1alpha1/contactPoint/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'alerting.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'alerting.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/alerting/v1alpha1/messageTemplate/main.libsonnet
+++ b/grafanaplane/alerting/v1alpha1/messageTemplate/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'alerting.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'alerting.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/alerting/v1alpha1/muteTiming/main.libsonnet
+++ b/grafanaplane/alerting/v1alpha1/muteTiming/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'alerting.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'alerting.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/alerting/v1alpha1/notificationPolicy/main.libsonnet
+++ b/grafanaplane/alerting/v1alpha1/notificationPolicy/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'alerting.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'alerting.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/alerting/v1alpha1/ruleGroup/main.libsonnet
+++ b/grafanaplane/alerting/v1alpha1/ruleGroup/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'alerting.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'alerting.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/cloud/v1alpha1/accessPolicy/main.libsonnet
+++ b/grafanaplane/cloud/v1alpha1/accessPolicy/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'cloud.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'cloud.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/cloud/v1alpha1/accessPolicyToken/main.libsonnet
+++ b/grafanaplane/cloud/v1alpha1/accessPolicyToken/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'cloud.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'cloud.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/cloud/v1alpha1/pluginInstallation/main.libsonnet
+++ b/grafanaplane/cloud/v1alpha1/pluginInstallation/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'cloud.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'cloud.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/cloud/v1alpha1/stack/main.libsonnet
+++ b/grafanaplane/cloud/v1alpha1/stack/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'cloud.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'cloud.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/cloud/v1alpha1/stackServiceAccount/main.libsonnet
+++ b/grafanaplane/cloud/v1alpha1/stackServiceAccount/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'cloud.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'cloud.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/cloud/v1alpha1/stackServiceAccountToken/main.libsonnet
+++ b/grafanaplane/cloud/v1alpha1/stackServiceAccountToken/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'cloud.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'cloud.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/enterprise/v1alpha1/dataSourcePermission/main.libsonnet
+++ b/grafanaplane/enterprise/v1alpha1/dataSourcePermission/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'enterprise.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'enterprise.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/enterprise/v1alpha1/report/main.libsonnet
+++ b/grafanaplane/enterprise/v1alpha1/report/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'enterprise.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'enterprise.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/enterprise/v1alpha1/role/main.libsonnet
+++ b/grafanaplane/enterprise/v1alpha1/role/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'enterprise.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'enterprise.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/enterprise/v1alpha1/roleAssignment/main.libsonnet
+++ b/grafanaplane/enterprise/v1alpha1/roleAssignment/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'enterprise.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'enterprise.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/enterprise/v1alpha1/teamExternalGroup/main.libsonnet
+++ b/grafanaplane/enterprise/v1alpha1/teamExternalGroup/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'enterprise.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'enterprise.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/ml/v1alpha1/holiday/main.libsonnet
+++ b/grafanaplane/ml/v1alpha1/holiday/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'ml.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'ml.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/ml/v1alpha1/job/main.libsonnet
+++ b/grafanaplane/ml/v1alpha1/job/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'ml.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'ml.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/ml/v1alpha1/outlierDetector/main.libsonnet
+++ b/grafanaplane/ml/v1alpha1/outlierDetector/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'ml.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'ml.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/escalation/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/escalation/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/escalationChain/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/escalationChain/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/integration/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/integration/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/onCallShift/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/onCallShift/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/outgoingWebhook/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/outgoingWebhook/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/route/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/route/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/schedule/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/schedule/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oncall/v1alpha1/userNotificationRule/main.libsonnet
+++ b/grafanaplane/oncall/v1alpha1/userNotificationRule/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oncall.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oncall.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/annotation/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/annotation/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/dashboard/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/dashboard/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/dashboardPermission/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/dashboardPermission/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/dashboardPublic/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/dashboardPublic/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/dataSource/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/dataSource/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/folder/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/folder/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/folderPermission/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/folderPermission/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/libraryPanel/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/libraryPanel/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/organization/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/organization/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/organizationPreferences/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/organizationPreferences/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/playlist/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/playlist/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/serviceAccount/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/serviceAccount/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/serviceAccountPermission/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/serviceAccountPermission/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/serviceAccountToken/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/serviceAccountToken/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/ssoSettings/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/ssoSettings/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/team/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/team/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/oss/v1alpha1/user/main.libsonnet
+++ b/grafanaplane/oss/v1alpha1/user/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'oss.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'oss.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/slo/v1alpha1/slo/main.libsonnet
+++ b/grafanaplane/slo/v1alpha1/slo/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'slo.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'slo.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/sm/v1alpha1/check/main.libsonnet
+++ b/grafanaplane/sm/v1alpha1/check/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'sm.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'sm.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/sm/v1alpha1/installation/main.libsonnet
+++ b/grafanaplane/sm/v1alpha1/installation/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'sm.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'sm.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/grafanaplane/sm/v1alpha1/probe/main.libsonnet
+++ b/grafanaplane/sm/v1alpha1/probe/main.libsonnet
@@ -7,7 +7,7 @@
     + self.metadata.withName(name),
   '#withApiVersion': { 'function': { args: [], help: '' } },
   withApiVersion(): {
-    apiVersion: 'sm.grafana.crossplane.io.namespaced/v1alpha1',
+    apiVersion: 'sm.grafana.net.namespaced/v1alpha1',
   },
   '#withKind': { 'function': { args: [], help: '' } },
   withKind(): {

--- a/packages/grafana-namespaced-alerting/CompositeResourceDefinition-ContactPoint.yaml
+++ b/packages/grafana-namespaced-alerting/CompositeResourceDefinition-ContactPoint.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xcontactpoints.alerting.grafana.crossplane.io.namespaced
+  name: xcontactpoints.alerting.grafana.net.namespaced
 spec:
   claimNames:
     kind: ContactPoint
     plural: contactpoints
   defaultCompositionRef:
     name: contactpoint-namespaced
-  group: alerting.grafana.crossplane.io.namespaced
+  group: alerting.grafana.net.namespaced
   names:
     kind: XContactPoint
     plural: xcontactpoints

--- a/packages/grafana-namespaced-alerting/CompositeResourceDefinition-MessageTemplate.yaml
+++ b/packages/grafana-namespaced-alerting/CompositeResourceDefinition-MessageTemplate.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xmessagetemplates.alerting.grafana.crossplane.io.namespaced
+  name: xmessagetemplates.alerting.grafana.net.namespaced
 spec:
   claimNames:
     kind: MessageTemplate
     plural: messagetemplates
   defaultCompositionRef:
     name: messagetemplate-namespaced
-  group: alerting.grafana.crossplane.io.namespaced
+  group: alerting.grafana.net.namespaced
   names:
     kind: XMessageTemplate
     plural: xmessagetemplates

--- a/packages/grafana-namespaced-alerting/CompositeResourceDefinition-MuteTiming.yaml
+++ b/packages/grafana-namespaced-alerting/CompositeResourceDefinition-MuteTiming.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xmutetimings.alerting.grafana.crossplane.io.namespaced
+  name: xmutetimings.alerting.grafana.net.namespaced
 spec:
   claimNames:
     kind: MuteTiming
     plural: mutetimings
   defaultCompositionRef:
     name: mutetiming-namespaced
-  group: alerting.grafana.crossplane.io.namespaced
+  group: alerting.grafana.net.namespaced
   names:
     kind: XMuteTiming
     plural: xmutetimings

--- a/packages/grafana-namespaced-alerting/CompositeResourceDefinition-NotificationPolicy.yaml
+++ b/packages/grafana-namespaced-alerting/CompositeResourceDefinition-NotificationPolicy.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xnotificationpolicies.alerting.grafana.crossplane.io.namespaced
+  name: xnotificationpolicies.alerting.grafana.net.namespaced
 spec:
   claimNames:
     kind: NotificationPolicy
     plural: notificationpolicies
   defaultCompositionRef:
     name: notificationpolicy-namespaced
-  group: alerting.grafana.crossplane.io.namespaced
+  group: alerting.grafana.net.namespaced
   names:
     kind: XNotificationPolicy
     plural: xnotificationpolicies

--- a/packages/grafana-namespaced-alerting/CompositeResourceDefinition-RuleGroup.yaml
+++ b/packages/grafana-namespaced-alerting/CompositeResourceDefinition-RuleGroup.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xrulegroups.alerting.grafana.crossplane.io.namespaced
+  name: xrulegroups.alerting.grafana.net.namespaced
 spec:
   claimNames:
     kind: RuleGroup
     plural: rulegroups
   defaultCompositionRef:
     name: rulegroup-namespaced
-  group: alerting.grafana.crossplane.io.namespaced
+  group: alerting.grafana.net.namespaced
   names:
     kind: XRuleGroup
     plural: xrulegroups

--- a/packages/grafana-namespaced-alerting/Composition-ContactPoint.yaml
+++ b/packages/grafana-namespaced-alerting/Composition-ContactPoint.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xcontactpoints.alerting.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xcontactpoints.alerting.grafana.net.namespaced
   name: contactpoint-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: alerting.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: alerting.grafana.net.namespaced/v1alpha1
     kind: XContactPoint
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-alerting/Composition-MessageTemplate.yaml
+++ b/packages/grafana-namespaced-alerting/Composition-MessageTemplate.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xmessagetemplates.alerting.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xmessagetemplates.alerting.grafana.net.namespaced
   name: messagetemplate-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: alerting.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: alerting.grafana.net.namespaced/v1alpha1
     kind: XMessageTemplate
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-alerting/Composition-MuteTiming.yaml
+++ b/packages/grafana-namespaced-alerting/Composition-MuteTiming.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xmutetimings.alerting.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xmutetimings.alerting.grafana.net.namespaced
   name: mutetiming-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: alerting.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: alerting.grafana.net.namespaced/v1alpha1
     kind: XMuteTiming
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-alerting/Composition-NotificationPolicy.yaml
+++ b/packages/grafana-namespaced-alerting/Composition-NotificationPolicy.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xnotificationpolicies.alerting.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xnotificationpolicies.alerting.grafana.net.namespaced
   name: notificationpolicy-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: alerting.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: alerting.grafana.net.namespaced/v1alpha1
     kind: XNotificationPolicy
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-alerting/Composition-RuleGroup.yaml
+++ b/packages/grafana-namespaced-alerting/Composition-RuleGroup.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xrulegroups.alerting.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xrulegroups.alerting.grafana.net.namespaced
   name: rulegroup-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: alerting.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: alerting.grafana.net.namespaced/v1alpha1
     kind: XRuleGroup
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-cloud/CompositeResourceDefinition-AccessPolicy.yaml
+++ b/packages/grafana-namespaced-cloud/CompositeResourceDefinition-AccessPolicy.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xaccesspolicies.cloud.grafana.crossplane.io.namespaced
+  name: xaccesspolicies.cloud.grafana.net.namespaced
 spec:
   claimNames:
     kind: AccessPolicy
     plural: accesspolicies
   defaultCompositionRef:
     name: accesspolicy-namespaced
-  group: cloud.grafana.crossplane.io.namespaced
+  group: cloud.grafana.net.namespaced
   names:
     kind: XAccessPolicy
     plural: xaccesspolicies

--- a/packages/grafana-namespaced-cloud/CompositeResourceDefinition-AccessPolicyToken.yaml
+++ b/packages/grafana-namespaced-cloud/CompositeResourceDefinition-AccessPolicyToken.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xaccesspolicytokens.cloud.grafana.crossplane.io.namespaced
+  name: xaccesspolicytokens.cloud.grafana.net.namespaced
 spec:
   claimNames:
     kind: AccessPolicyToken
     plural: accesspolicytokens
   defaultCompositionRef:
     name: accesspolicytoken-namespaced
-  group: cloud.grafana.crossplane.io.namespaced
+  group: cloud.grafana.net.namespaced
   names:
     kind: XAccessPolicyToken
     plural: xaccesspolicytokens

--- a/packages/grafana-namespaced-cloud/CompositeResourceDefinition-PluginInstallation.yaml
+++ b/packages/grafana-namespaced-cloud/CompositeResourceDefinition-PluginInstallation.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xplugininstallations.cloud.grafana.crossplane.io.namespaced
+  name: xplugininstallations.cloud.grafana.net.namespaced
 spec:
   claimNames:
     kind: PluginInstallation
     plural: plugininstallations
   defaultCompositionRef:
     name: plugininstallation-namespaced
-  group: cloud.grafana.crossplane.io.namespaced
+  group: cloud.grafana.net.namespaced
   names:
     kind: XPluginInstallation
     plural: xplugininstallations

--- a/packages/grafana-namespaced-cloud/CompositeResourceDefinition-Stack.yaml
+++ b/packages/grafana-namespaced-cloud/CompositeResourceDefinition-Stack.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xstacks.cloud.grafana.crossplane.io.namespaced
+  name: xstacks.cloud.grafana.net.namespaced
 spec:
   claimNames:
     kind: Stack
     plural: stacks
   defaultCompositionRef:
     name: stack-namespaced
-  group: cloud.grafana.crossplane.io.namespaced
+  group: cloud.grafana.net.namespaced
   names:
     kind: XStack
     plural: xstacks

--- a/packages/grafana-namespaced-cloud/CompositeResourceDefinition-StackServiceAccount.yaml
+++ b/packages/grafana-namespaced-cloud/CompositeResourceDefinition-StackServiceAccount.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xstackserviceaccounts.cloud.grafana.crossplane.io.namespaced
+  name: xstackserviceaccounts.cloud.grafana.net.namespaced
 spec:
   claimNames:
     kind: StackServiceAccount
     plural: stackserviceaccounts
   defaultCompositionRef:
     name: stackserviceaccount-namespaced
-  group: cloud.grafana.crossplane.io.namespaced
+  group: cloud.grafana.net.namespaced
   names:
     kind: XStackServiceAccount
     plural: xstackserviceaccounts

--- a/packages/grafana-namespaced-cloud/CompositeResourceDefinition-StackServiceAccountToken.yaml
+++ b/packages/grafana-namespaced-cloud/CompositeResourceDefinition-StackServiceAccountToken.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xstackserviceaccounttokens.cloud.grafana.crossplane.io.namespaced
+  name: xstackserviceaccounttokens.cloud.grafana.net.namespaced
 spec:
   claimNames:
     kind: StackServiceAccountToken
     plural: stackserviceaccounttokens
   defaultCompositionRef:
     name: stackserviceaccounttoken-namespaced
-  group: cloud.grafana.crossplane.io.namespaced
+  group: cloud.grafana.net.namespaced
   names:
     kind: XStackServiceAccountToken
     plural: xstackserviceaccounttokens

--- a/packages/grafana-namespaced-cloud/Composition-AccessPolicy.yaml
+++ b/packages/grafana-namespaced-cloud/Composition-AccessPolicy.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xaccesspolicies.cloud.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xaccesspolicies.cloud.grafana.net.namespaced
   name: accesspolicy-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: cloud.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: cloud.grafana.net.namespaced/v1alpha1
     kind: XAccessPolicy
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-cloud/Composition-AccessPolicyToken.yaml
+++ b/packages/grafana-namespaced-cloud/Composition-AccessPolicyToken.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xaccesspolicytokens.cloud.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xaccesspolicytokens.cloud.grafana.net.namespaced
   name: accesspolicytoken-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: cloud.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: cloud.grafana.net.namespaced/v1alpha1
     kind: XAccessPolicyToken
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-cloud/Composition-PluginInstallation.yaml
+++ b/packages/grafana-namespaced-cloud/Composition-PluginInstallation.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xplugininstallations.cloud.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xplugininstallations.cloud.grafana.net.namespaced
   name: plugininstallation-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: cloud.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: cloud.grafana.net.namespaced/v1alpha1
     kind: XPluginInstallation
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-cloud/Composition-Stack.yaml
+++ b/packages/grafana-namespaced-cloud/Composition-Stack.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xstacks.cloud.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xstacks.cloud.grafana.net.namespaced
   name: stack-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: cloud.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: cloud.grafana.net.namespaced/v1alpha1
     kind: XStack
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-cloud/Composition-StackServiceAccount.yaml
+++ b/packages/grafana-namespaced-cloud/Composition-StackServiceAccount.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xstackserviceaccounts.cloud.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xstackserviceaccounts.cloud.grafana.net.namespaced
   name: stackserviceaccount-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: cloud.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: cloud.grafana.net.namespaced/v1alpha1
     kind: XStackServiceAccount
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-cloud/Composition-StackServiceAccountToken.yaml
+++ b/packages/grafana-namespaced-cloud/Composition-StackServiceAccountToken.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xstackserviceaccounttokens.cloud.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xstackserviceaccounttokens.cloud.grafana.net.namespaced
   name: stackserviceaccounttoken-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: cloud.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: cloud.grafana.net.namespaced/v1alpha1
     kind: XStackServiceAccountToken
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-DataSourcePermission.yaml
+++ b/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-DataSourcePermission.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xdatasourcepermissions.enterprise.grafana.crossplane.io.namespaced
+  name: xdatasourcepermissions.enterprise.grafana.net.namespaced
 spec:
   claimNames:
     kind: DataSourcePermission
     plural: datasourcepermissions
   defaultCompositionRef:
     name: datasourcepermission-namespaced
-  group: enterprise.grafana.crossplane.io.namespaced
+  group: enterprise.grafana.net.namespaced
   names:
     kind: XDataSourcePermission
     plural: xdatasourcepermissions

--- a/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-Report.yaml
+++ b/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-Report.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xreports.enterprise.grafana.crossplane.io.namespaced
+  name: xreports.enterprise.grafana.net.namespaced
 spec:
   claimNames:
     kind: Report
     plural: reports
   defaultCompositionRef:
     name: report-namespaced
-  group: enterprise.grafana.crossplane.io.namespaced
+  group: enterprise.grafana.net.namespaced
   names:
     kind: XReport
     plural: xreports

--- a/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-Role.yaml
+++ b/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-Role.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xroles.enterprise.grafana.crossplane.io.namespaced
+  name: xroles.enterprise.grafana.net.namespaced
 spec:
   claimNames:
     kind: Role
     plural: roles
   defaultCompositionRef:
     name: role-namespaced
-  group: enterprise.grafana.crossplane.io.namespaced
+  group: enterprise.grafana.net.namespaced
   names:
     kind: XRole
     plural: xroles

--- a/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-RoleAssignment.yaml
+++ b/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-RoleAssignment.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xroleassignments.enterprise.grafana.crossplane.io.namespaced
+  name: xroleassignments.enterprise.grafana.net.namespaced
 spec:
   claimNames:
     kind: RoleAssignment
     plural: roleassignments
   defaultCompositionRef:
     name: roleassignment-namespaced
-  group: enterprise.grafana.crossplane.io.namespaced
+  group: enterprise.grafana.net.namespaced
   names:
     kind: XRoleAssignment
     plural: xroleassignments

--- a/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-TeamExternalGroup.yaml
+++ b/packages/grafana-namespaced-enterprise/CompositeResourceDefinition-TeamExternalGroup.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xteamexternalgroups.enterprise.grafana.crossplane.io.namespaced
+  name: xteamexternalgroups.enterprise.grafana.net.namespaced
 spec:
   claimNames:
     kind: TeamExternalGroup
     plural: teamexternalgroups
   defaultCompositionRef:
     name: teamexternalgroup-namespaced
-  group: enterprise.grafana.crossplane.io.namespaced
+  group: enterprise.grafana.net.namespaced
   names:
     kind: XTeamExternalGroup
     plural: xteamexternalgroups

--- a/packages/grafana-namespaced-enterprise/Composition-DataSourcePermission.yaml
+++ b/packages/grafana-namespaced-enterprise/Composition-DataSourcePermission.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xdatasourcepermissions.enterprise.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xdatasourcepermissions.enterprise.grafana.net.namespaced
   name: datasourcepermission-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: enterprise.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: enterprise.grafana.net.namespaced/v1alpha1
     kind: XDataSourcePermission
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-enterprise/Composition-Report.yaml
+++ b/packages/grafana-namespaced-enterprise/Composition-Report.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xreports.enterprise.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xreports.enterprise.grafana.net.namespaced
   name: report-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: enterprise.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: enterprise.grafana.net.namespaced/v1alpha1
     kind: XReport
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-enterprise/Composition-Role.yaml
+++ b/packages/grafana-namespaced-enterprise/Composition-Role.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xroles.enterprise.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xroles.enterprise.grafana.net.namespaced
   name: role-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: enterprise.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: enterprise.grafana.net.namespaced/v1alpha1
     kind: XRole
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-enterprise/Composition-RoleAssignment.yaml
+++ b/packages/grafana-namespaced-enterprise/Composition-RoleAssignment.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xroleassignments.enterprise.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xroleassignments.enterprise.grafana.net.namespaced
   name: roleassignment-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: enterprise.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: enterprise.grafana.net.namespaced/v1alpha1
     kind: XRoleAssignment
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-enterprise/Composition-TeamExternalGroup.yaml
+++ b/packages/grafana-namespaced-enterprise/Composition-TeamExternalGroup.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xteamexternalgroups.enterprise.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xteamexternalgroups.enterprise.grafana.net.namespaced
   name: teamexternalgroup-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: enterprise.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: enterprise.grafana.net.namespaced/v1alpha1
     kind: XTeamExternalGroup
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-ml/CompositeResourceDefinition-Holiday.yaml
+++ b/packages/grafana-namespaced-ml/CompositeResourceDefinition-Holiday.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xholidays.ml.grafana.crossplane.io.namespaced
+  name: xholidays.ml.grafana.net.namespaced
 spec:
   claimNames:
     kind: Holiday
     plural: holidays
   defaultCompositionRef:
     name: holiday-namespaced
-  group: ml.grafana.crossplane.io.namespaced
+  group: ml.grafana.net.namespaced
   names:
     kind: XHoliday
     plural: xholidays

--- a/packages/grafana-namespaced-ml/CompositeResourceDefinition-Job.yaml
+++ b/packages/grafana-namespaced-ml/CompositeResourceDefinition-Job.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xjobs.ml.grafana.crossplane.io.namespaced
+  name: xjobs.ml.grafana.net.namespaced
 spec:
   claimNames:
     kind: Job
     plural: jobs
   defaultCompositionRef:
     name: job-namespaced
-  group: ml.grafana.crossplane.io.namespaced
+  group: ml.grafana.net.namespaced
   names:
     kind: XJob
     plural: xjobs

--- a/packages/grafana-namespaced-ml/CompositeResourceDefinition-OutlierDetector.yaml
+++ b/packages/grafana-namespaced-ml/CompositeResourceDefinition-OutlierDetector.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xoutlierdetectors.ml.grafana.crossplane.io.namespaced
+  name: xoutlierdetectors.ml.grafana.net.namespaced
 spec:
   claimNames:
     kind: OutlierDetector
     plural: outlierdetectors
   defaultCompositionRef:
     name: outlierdetector-namespaced
-  group: ml.grafana.crossplane.io.namespaced
+  group: ml.grafana.net.namespaced
   names:
     kind: XOutlierDetector
     plural: xoutlierdetectors

--- a/packages/grafana-namespaced-ml/Composition-Holiday.yaml
+++ b/packages/grafana-namespaced-ml/Composition-Holiday.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xholidays.ml.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xholidays.ml.grafana.net.namespaced
   name: holiday-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: ml.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: ml.grafana.net.namespaced/v1alpha1
     kind: XHoliday
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-ml/Composition-Job.yaml
+++ b/packages/grafana-namespaced-ml/Composition-Job.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xjobs.ml.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xjobs.ml.grafana.net.namespaced
   name: job-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: ml.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: ml.grafana.net.namespaced/v1alpha1
     kind: XJob
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-ml/Composition-OutlierDetector.yaml
+++ b/packages/grafana-namespaced-ml/Composition-OutlierDetector.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xoutlierdetectors.ml.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xoutlierdetectors.ml.grafana.net.namespaced
   name: outlierdetector-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: ml.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: ml.grafana.net.namespaced/v1alpha1
     kind: XOutlierDetector
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Escalation.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Escalation.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xescalations.oncall.grafana.crossplane.io.namespaced
+  name: xescalations.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: Escalation
     plural: escalations
   defaultCompositionRef:
     name: escalation-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XEscalation
     plural: xescalations

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-EscalationChain.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-EscalationChain.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xescalationchains.oncall.grafana.crossplane.io.namespaced
+  name: xescalationchains.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: EscalationChain
     plural: escalationchains
   defaultCompositionRef:
     name: escalationchain-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XEscalationChain
     plural: xescalationchains

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Integration.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Integration.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xintegrations.oncall.grafana.crossplane.io.namespaced
+  name: xintegrations.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: Integration
     plural: integrations
   defaultCompositionRef:
     name: integration-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XIntegration
     plural: xintegrations

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-OnCallShift.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-OnCallShift.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xoncallshifts.oncall.grafana.crossplane.io.namespaced
+  name: xoncallshifts.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: OnCallShift
     plural: oncallshifts
   defaultCompositionRef:
     name: oncallshift-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XOnCallShift
     plural: xoncallshifts

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-OutgoingWebhook.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-OutgoingWebhook.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xoutgoingwebhooks.oncall.grafana.crossplane.io.namespaced
+  name: xoutgoingwebhooks.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: OutgoingWebhook
     plural: outgoingwebhooks
   defaultCompositionRef:
     name: outgoingwebhook-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XOutgoingWebhook
     plural: xoutgoingwebhooks

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Route.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Route.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xroutes.oncall.grafana.crossplane.io.namespaced
+  name: xroutes.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: Route
     plural: routes
   defaultCompositionRef:
     name: route-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XRoute
     plural: xroutes

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Schedule.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-Schedule.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xschedules.oncall.grafana.crossplane.io.namespaced
+  name: xschedules.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: Schedule
     plural: schedules
   defaultCompositionRef:
     name: schedule-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XSchedule
     plural: xschedules

--- a/packages/grafana-namespaced-oncall/CompositeResourceDefinition-UserNotificationRule.yaml
+++ b/packages/grafana-namespaced-oncall/CompositeResourceDefinition-UserNotificationRule.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xusernotificationrules.oncall.grafana.crossplane.io.namespaced
+  name: xusernotificationrules.oncall.grafana.net.namespaced
 spec:
   claimNames:
     kind: UserNotificationRule
     plural: usernotificationrules
   defaultCompositionRef:
     name: usernotificationrule-namespaced
-  group: oncall.grafana.crossplane.io.namespaced
+  group: oncall.grafana.net.namespaced
   names:
     kind: XUserNotificationRule
     plural: xusernotificationrules

--- a/packages/grafana-namespaced-oncall/Composition-Escalation.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-Escalation.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xescalations.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xescalations.oncall.grafana.net.namespaced
   name: escalation-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XEscalation
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/Composition-EscalationChain.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-EscalationChain.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xescalationchains.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xescalationchains.oncall.grafana.net.namespaced
   name: escalationchain-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XEscalationChain
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/Composition-Integration.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-Integration.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xintegrations.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xintegrations.oncall.grafana.net.namespaced
   name: integration-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XIntegration
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/Composition-OnCallShift.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-OnCallShift.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xoncallshifts.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xoncallshifts.oncall.grafana.net.namespaced
   name: oncallshift-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XOnCallShift
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/Composition-OutgoingWebhook.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-OutgoingWebhook.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xoutgoingwebhooks.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xoutgoingwebhooks.oncall.grafana.net.namespaced
   name: outgoingwebhook-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XOutgoingWebhook
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/Composition-Route.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-Route.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xroutes.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xroutes.oncall.grafana.net.namespaced
   name: route-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XRoute
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/Composition-Schedule.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-Schedule.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xschedules.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xschedules.oncall.grafana.net.namespaced
   name: schedule-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XSchedule
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oncall/Composition-UserNotificationRule.yaml
+++ b/packages/grafana-namespaced-oncall/Composition-UserNotificationRule.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xusernotificationrules.oncall.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xusernotificationrules.oncall.grafana.net.namespaced
   name: usernotificationrule-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oncall.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oncall.grafana.net.namespaced/v1alpha1
     kind: XUserNotificationRule
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-Annotation.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-Annotation.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xannotations.oss.grafana.crossplane.io.namespaced
+  name: xannotations.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: Annotation
     plural: annotations
   defaultCompositionRef:
     name: annotation-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XAnnotation
     plural: xannotations

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-Dashboard.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-Dashboard.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xdashboards.oss.grafana.crossplane.io.namespaced
+  name: xdashboards.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: Dashboard
     plural: dashboards
   defaultCompositionRef:
     name: dashboard-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XDashboard
     plural: xdashboards

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-DashboardPermission.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-DashboardPermission.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xdashboardpermissions.oss.grafana.crossplane.io.namespaced
+  name: xdashboardpermissions.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: DashboardPermission
     plural: dashboardpermissions
   defaultCompositionRef:
     name: dashboardpermission-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XDashboardPermission
     plural: xdashboardpermissions

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-DashboardPublic.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-DashboardPublic.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xdashboardpublics.oss.grafana.crossplane.io.namespaced
+  name: xdashboardpublics.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: DashboardPublic
     plural: dashboardpublics
   defaultCompositionRef:
     name: dashboardpublic-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XDashboardPublic
     plural: xdashboardpublics

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-DataSource.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-DataSource.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xdatasources.oss.grafana.crossplane.io.namespaced
+  name: xdatasources.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: DataSource
     plural: datasources
   defaultCompositionRef:
     name: datasource-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XDataSource
     plural: xdatasources

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-Folder.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-Folder.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xfolders.oss.grafana.crossplane.io.namespaced
+  name: xfolders.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: Folder
     plural: folders
   defaultCompositionRef:
     name: folder-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XFolder
     plural: xfolders

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-FolderPermission.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-FolderPermission.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xfolderpermissions.oss.grafana.crossplane.io.namespaced
+  name: xfolderpermissions.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: FolderPermission
     plural: folderpermissions
   defaultCompositionRef:
     name: folderpermission-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XFolderPermission
     plural: xfolderpermissions

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-LibraryPanel.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-LibraryPanel.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xlibrarypanels.oss.grafana.crossplane.io.namespaced
+  name: xlibrarypanels.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: LibraryPanel
     plural: librarypanels
   defaultCompositionRef:
     name: librarypanel-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XLibraryPanel
     plural: xlibrarypanels

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-Organization.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-Organization.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xorganizations.oss.grafana.crossplane.io.namespaced
+  name: xorganizations.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: Organization
     plural: organizations
   defaultCompositionRef:
     name: organization-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XOrganization
     plural: xorganizations

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-OrganizationPreferences.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-OrganizationPreferences.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xorganizationpreferences.oss.grafana.crossplane.io.namespaced
+  name: xorganizationpreferences.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: OrganizationPreferences
     plural: organizationpreferences
   defaultCompositionRef:
     name: organizationpreferences-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XOrganizationPreferences
     plural: xorganizationpreferences

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-Playlist.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-Playlist.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xplaylists.oss.grafana.crossplane.io.namespaced
+  name: xplaylists.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: Playlist
     plural: playlists
   defaultCompositionRef:
     name: playlist-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XPlaylist
     plural: xplaylists

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-ServiceAccount.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-ServiceAccount.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xserviceaccounts.oss.grafana.crossplane.io.namespaced
+  name: xserviceaccounts.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: ServiceAccount
     plural: serviceaccounts
   defaultCompositionRef:
     name: serviceaccount-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XServiceAccount
     plural: xserviceaccounts

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-ServiceAccountPermission.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-ServiceAccountPermission.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xserviceaccountpermissions.oss.grafana.crossplane.io.namespaced
+  name: xserviceaccountpermissions.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: ServiceAccountPermission
     plural: serviceaccountpermissions
   defaultCompositionRef:
     name: serviceaccountpermission-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XServiceAccountPermission
     plural: xserviceaccountpermissions

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-ServiceAccountToken.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-ServiceAccountToken.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xserviceaccounttokens.oss.grafana.crossplane.io.namespaced
+  name: xserviceaccounttokens.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: ServiceAccountToken
     plural: serviceaccounttokens
   defaultCompositionRef:
     name: serviceaccounttoken-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XServiceAccountToken
     plural: xserviceaccounttokens

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-SsoSettings.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-SsoSettings.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xssosettings.oss.grafana.crossplane.io.namespaced
+  name: xssosettings.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: SsoSettings
     plural: ssosettings
   defaultCompositionRef:
     name: ssosettings-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XSsoSettings
     plural: xssosettings

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-Team.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-Team.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xteams.oss.grafana.crossplane.io.namespaced
+  name: xteams.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: Team
     plural: teams
   defaultCompositionRef:
     name: team-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XTeam
     plural: xteams

--- a/packages/grafana-namespaced-oss/CompositeResourceDefinition-User.yaml
+++ b/packages/grafana-namespaced-oss/CompositeResourceDefinition-User.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xusers.oss.grafana.crossplane.io.namespaced
+  name: xusers.oss.grafana.net.namespaced
 spec:
   claimNames:
     kind: User
     plural: users
   defaultCompositionRef:
     name: user-namespaced
-  group: oss.grafana.crossplane.io.namespaced
+  group: oss.grafana.net.namespaced
   names:
     kind: XUser
     plural: xusers

--- a/packages/grafana-namespaced-oss/Composition-Annotation.yaml
+++ b/packages/grafana-namespaced-oss/Composition-Annotation.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xannotations.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xannotations.oss.grafana.net.namespaced
   name: annotation-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XAnnotation
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-Dashboard.yaml
+++ b/packages/grafana-namespaced-oss/Composition-Dashboard.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xdashboards.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xdashboards.oss.grafana.net.namespaced
   name: dashboard-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XDashboard
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-DashboardPermission.yaml
+++ b/packages/grafana-namespaced-oss/Composition-DashboardPermission.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xdashboardpermissions.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xdashboardpermissions.oss.grafana.net.namespaced
   name: dashboardpermission-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XDashboardPermission
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-DashboardPublic.yaml
+++ b/packages/grafana-namespaced-oss/Composition-DashboardPublic.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xdashboardpublics.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xdashboardpublics.oss.grafana.net.namespaced
   name: dashboardpublic-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XDashboardPublic
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-DataSource.yaml
+++ b/packages/grafana-namespaced-oss/Composition-DataSource.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xdatasources.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xdatasources.oss.grafana.net.namespaced
   name: datasource-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XDataSource
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-Folder.yaml
+++ b/packages/grafana-namespaced-oss/Composition-Folder.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xfolders.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xfolders.oss.grafana.net.namespaced
   name: folder-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XFolder
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-FolderPermission.yaml
+++ b/packages/grafana-namespaced-oss/Composition-FolderPermission.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xfolderpermissions.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xfolderpermissions.oss.grafana.net.namespaced
   name: folderpermission-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XFolderPermission
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-LibraryPanel.yaml
+++ b/packages/grafana-namespaced-oss/Composition-LibraryPanel.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xlibrarypanels.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xlibrarypanels.oss.grafana.net.namespaced
   name: librarypanel-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XLibraryPanel
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-Organization.yaml
+++ b/packages/grafana-namespaced-oss/Composition-Organization.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xorganizations.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xorganizations.oss.grafana.net.namespaced
   name: organization-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XOrganization
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-OrganizationPreferences.yaml
+++ b/packages/grafana-namespaced-oss/Composition-OrganizationPreferences.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xorganizationpreferences.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xorganizationpreferences.oss.grafana.net.namespaced
   name: organizationpreferences-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XOrganizationPreferences
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-Playlist.yaml
+++ b/packages/grafana-namespaced-oss/Composition-Playlist.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xplaylists.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xplaylists.oss.grafana.net.namespaced
   name: playlist-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XPlaylist
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-ServiceAccount.yaml
+++ b/packages/grafana-namespaced-oss/Composition-ServiceAccount.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xserviceaccounts.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xserviceaccounts.oss.grafana.net.namespaced
   name: serviceaccount-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XServiceAccount
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-ServiceAccountPermission.yaml
+++ b/packages/grafana-namespaced-oss/Composition-ServiceAccountPermission.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xserviceaccountpermissions.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xserviceaccountpermissions.oss.grafana.net.namespaced
   name: serviceaccountpermission-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XServiceAccountPermission
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-ServiceAccountToken.yaml
+++ b/packages/grafana-namespaced-oss/Composition-ServiceAccountToken.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xserviceaccounttokens.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xserviceaccounttokens.oss.grafana.net.namespaced
   name: serviceaccounttoken-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XServiceAccountToken
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-SsoSettings.yaml
+++ b/packages/grafana-namespaced-oss/Composition-SsoSettings.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xssosettings.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xssosettings.oss.grafana.net.namespaced
   name: ssosettings-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XSsoSettings
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-Team.yaml
+++ b/packages/grafana-namespaced-oss/Composition-Team.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xteams.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xteams.oss.grafana.net.namespaced
   name: team-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XTeam
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-oss/Composition-User.yaml
+++ b/packages/grafana-namespaced-oss/Composition-User.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xusers.oss.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xusers.oss.grafana.net.namespaced
   name: user-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: oss.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: oss.grafana.net.namespaced/v1alpha1
     kind: XUser
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-slo/CompositeResourceDefinition-SLO.yaml
+++ b/packages/grafana-namespaced-slo/CompositeResourceDefinition-SLO.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xslos.slo.grafana.crossplane.io.namespaced
+  name: xslos.slo.grafana.net.namespaced
 spec:
   claimNames:
     kind: SLO
     plural: slos
   defaultCompositionRef:
     name: slo-namespaced
-  group: slo.grafana.crossplane.io.namespaced
+  group: slo.grafana.net.namespaced
   names:
     kind: XSLO
     plural: xslos

--- a/packages/grafana-namespaced-slo/Composition-SLO.yaml
+++ b/packages/grafana-namespaced-slo/Composition-SLO.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xslos.slo.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xslos.slo.grafana.net.namespaced
   name: slo-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: slo.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: slo.grafana.net.namespaced/v1alpha1
     kind: XSLO
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-sm/CompositeResourceDefinition-Check.yaml
+++ b/packages/grafana-namespaced-sm/CompositeResourceDefinition-Check.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xchecks.sm.grafana.crossplane.io.namespaced
+  name: xchecks.sm.grafana.net.namespaced
 spec:
   claimNames:
     kind: Check
     plural: checks
   defaultCompositionRef:
     name: check-namespaced
-  group: sm.grafana.crossplane.io.namespaced
+  group: sm.grafana.net.namespaced
   names:
     kind: XCheck
     plural: xchecks

--- a/packages/grafana-namespaced-sm/CompositeResourceDefinition-Installation.yaml
+++ b/packages/grafana-namespaced-sm/CompositeResourceDefinition-Installation.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xinstallations.sm.grafana.crossplane.io.namespaced
+  name: xinstallations.sm.grafana.net.namespaced
 spec:
   claimNames:
     kind: Installation
     plural: installations
   defaultCompositionRef:
     name: installation-namespaced
-  group: sm.grafana.crossplane.io.namespaced
+  group: sm.grafana.net.namespaced
   names:
     kind: XInstallation
     plural: xinstallations

--- a/packages/grafana-namespaced-sm/CompositeResourceDefinition-Probe.yaml
+++ b/packages/grafana-namespaced-sm/CompositeResourceDefinition-Probe.yaml
@@ -3,14 +3,14 @@ kind: CompositeResourceDefinition
 metadata:
   annotations:
     tanka.dev/namespaced: "false"
-  name: xprobes.sm.grafana.crossplane.io.namespaced
+  name: xprobes.sm.grafana.net.namespaced
 spec:
   claimNames:
     kind: Probe
     plural: probes
   defaultCompositionRef:
     name: probe-namespaced
-  group: sm.grafana.crossplane.io.namespaced
+  group: sm.grafana.net.namespaced
   names:
     kind: XProbe
     plural: xprobes

--- a/packages/grafana-namespaced-sm/Composition-Check.yaml
+++ b/packages/grafana-namespaced-sm/Composition-Check.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xchecks.sm.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xchecks.sm.grafana.net.namespaced
   name: check-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: sm.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: sm.grafana.net.namespaced/v1alpha1
     kind: XCheck
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-sm/Composition-Installation.yaml
+++ b/packages/grafana-namespaced-sm/Composition-Installation.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xinstallations.sm.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xinstallations.sm.grafana.net.namespaced
   name: installation-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: sm.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: sm.grafana.net.namespaced/v1alpha1
     kind: XInstallation
   mode: Pipeline
   pipeline:

--- a/packages/grafana-namespaced-sm/Composition-Probe.yaml
+++ b/packages/grafana-namespaced-sm/Composition-Probe.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     tanka.dev/namespaced: "false"
   labels:
-    crossplane.io/xrd: xprobes.sm.grafana.crossplane.io.namespaced
+    crossplane.io/xrd: xprobes.sm.grafana.net.namespaced
   name: probe-namespaced
 spec:
   compositeTypeRef:
-    apiVersion: sm.grafana.crossplane.io.namespaced/v1alpha1
+    apiVersion: sm.grafana.net.namespaced/v1alpha1
     kind: XProbe
   mode: Pipeline
   pipeline:


### PR DESCRIPTION
XRD metadata.name consists of `plural+group`, for some resources this became longer than 63 characters, which resulted in this error:

> 'cannot establish control of object: Composition.apiextensions.crossplane.io "stackserviceaccounttoken-namespaced" is invalid: metadata.labels: Invalid value:"xstackserviceaccounttokens.cloud.grafana.crossplane.io.namespaced": must be no more than 63 characters'

This PR replaces part of the group name: `s/crossplane.io/net` to trim of a few characters.

For review: first commit is the manual change, second has the generated files.