### PR TITLE
chore(security): remediate workflow zizmor issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: setup Crossplane cli
         uses: crossplane-contrib/setup-crossplane-action@cb8aac3f1246b19f101e7f85fd0a38623b4d5ad3 # v0.1.1
@@ -19,7 +23,7 @@ jobs:
           version: v0.20.0
 
       - name: setup jrsonnet
-        uses: grafana/shared-workflows/actions/setup-jrsonnet@main
+        uses: grafana/shared-workflows/actions/setup-jrsonnet@bc9486e0e7cbe24b54d0dcdf8be459eb777567b0
 
       - name: Build xpkg
         run: "make -B build"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -19,7 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: setup Crossplane cli
         uses: crossplane-contrib/setup-crossplane-action@cb8aac3f1246b19f101e7f85fd0a38623b4d5ad3 # v0.1.1
 


### PR DESCRIPTION
Fixed issues flagged by zizmor linting.

`build.yml`
1. "does not set persist-credentials: false" for `actions/checkout` (added it)
2. "overly broad permissions" for build job (added explicit permissions)
3. "action is not pinned to a hash" for `zendesk/setup-jsonnet` (changed to commit SHA)

`push.yml`
1. "does not set persist-credentials" for `actions/checkout`

zizmor also flagged several issues for workflow definitions under /generator/vendor/github.com/. I did not address those in this PR.

Trufflehog found one false-positive: `ftp://admin:password@example.com`