### PR TITLE
feat: upstream convenience functions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ local grafanaplane = import 'github.com/grafana/grafana-crossplane-libsonnet/gra
 
 ## Subpackages
 
+* [alerting](alerting/index.md)
 * [cloud](cloud.md)
 * [configurations](configurations.md)
 * [global](global.md)

--- a/docs/alerting/index.md
+++ b/docs/alerting/index.md
@@ -1,0 +1,7 @@
+# alerting
+
+Configure Grafana Managed Alerting (GMA)
+
+## Subpackages
+
+* [ruleGroup](ruleGroup/index.md)

--- a/docs/alerting/ruleGroup/index.md
+++ b/docs/alerting/ruleGroup/index.md
@@ -1,0 +1,56 @@
+# ruleGroup
+
+Provides functions to set up a ruleGroup.
+
+## Subpackages
+
+* [rules](rules.md)
+
+## Index
+
+* [`fn fromPrometheusRuleGroup(group, folderUid, datasourceUid="grafanacloud-prom")`](#fn-fromprometheusrulegroup)
+* [`fn new(name, folderUid)`](#fn-new)
+* [`fn withRules(rules)`](#fn-withrules)
+
+## Fields
+
+### fn fromPrometheusRuleGroup
+
+```jsonnet
+fromPrometheusRuleGroup(group, folderUid, datasourceUid="grafanacloud-prom")
+```
+
+PARAMETERS:
+
+* **group** (`object`)
+* **folderUid** (`string`)
+* **datasourceUid** (`string`)
+   - default value: `"grafanacloud-prom"`
+
+`fromPrometheusRuleGroup` creates a new rule group from a Prometheus rule group.
+
+ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+
+### fn new
+
+```jsonnet
+new(name, folderUid)
+```
+
+PARAMETERS:
+
+* **name** (`string`)
+* **folderUid** (`string`)
+
+`new` creates a new rule group resource.
+### fn withRules
+
+```jsonnet
+withRules(rules)
+```
+
+PARAMETERS:
+
+* **rules** (`array`)
+
+`withRules` adds rules to a rule group.

--- a/docs/alerting/ruleGroup/rules.md
+++ b/docs/alerting/ruleGroup/rules.md
@@ -1,0 +1,47 @@
+# ruleGroup.rules
+
+Provides functions to set up common rules.
+
+
+## Index
+
+* [`obj prometheus`](#obj-prometheus)
+  * [`fn fromAlertingRule(alertRule, datasourceUid="grafanacloud-prom")`](#fn-prometheusfromalertingrule)
+  * [`fn fromRecordingRule(recordingRule, datasourceUid="grafanacloud-prom")`](#fn-prometheusfromrecordingrule)
+
+## Fields
+
+### obj prometheus
+
+
+#### fn prometheus.fromAlertingRule
+
+```jsonnet
+prometheus.fromAlertingRule(alertRule, datasourceUid="grafanacloud-prom")
+```
+
+PARAMETERS:
+
+* **alertRule** (`object`)
+* **datasourceUid** (`string`)
+   - default value: `"grafanacloud-prom"`
+
+`fromAlertingRule` creates a Grafana Managed Alerting rule from a Prometheus alerting rule
+
+ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+
+#### fn prometheus.fromRecordingRule
+
+```jsonnet
+prometheus.fromRecordingRule(recordingRule, datasourceUid="grafanacloud-prom")
+```
+
+PARAMETERS:
+
+* **recordingRule** (`object`)
+* **datasourceUid** (`string`)
+   - default value: `"grafanacloud-prom"`
+
+`fromRecordingRule` creates a Grafana Managed Alerting rule from a Prometheus recording rule
+
+ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/

--- a/docs/sm/index.md
+++ b/docs/sm/index.md
@@ -9,8 +9,7 @@
 ## Index
 
 * [`obj check`](#obj-check)
-  * [`fn new(name, type)`](#fn-checknew)
-  * [`fn withFullProbeList(probes=[1,7,8,10,11,12,13,14,15,16,17,18,19,20,21,756,757,853,854,855,856,867])`](#fn-checkwithfullprobelist)
+  * [`fn new(name, job, url)`](#fn-checknew)
   * [`fn withHttpSettings(http)`](#fn-checkwithhttpsettings)
   * [`fn withHttpStatusCheck(validStatusCodes=[200])`](#fn-checkwithhttpstatuscheck)
   * [`fn withLabels(labels)`](#fn-checkwithlabels)
@@ -24,32 +23,21 @@
 #### fn check.new
 
 ```jsonnet
-check.new(name, type)
+check.new(name, job, url)
 ```
 
 PARAMETERS:
 
 * **name** (`string`)
-* **type** (`string`)
+* **job** (`string`)
+* **url** (`string`)
 
-`new` configures a synthetic monitoring check.
+`new` creates a new synthetic monitoring check for the betterops Grafana Cloud environment.
 
-Note: The probe list will match a short list of just three nodes across the globe.
-
-#### fn check.withFullProbeList
-
-```jsonnet
-check.withFullProbeList(probes=[1,7,8,10,11,12,13,14,15,16,17,18,19,20,21,756,757,853,854,855,856,867])
-```
-
-PARAMETERS:
-
-* **probes** (`array`)
-   - default value: `[1,7,8,10,11,12,13,14,15,16,17,18,19,20,21,756,757,853,854,855,856,867]`
-
-`withFullProbeList` sets the `probes` array to match the fulll list of probes.
-
-Note: Probe IDs hardcoded for now.
+Parameters:
+- `name`: Name of the check
+- `job`: Job identifier for the check
+- `url`: Target URL to monitor
 
 #### fn check.withHttpSettings
 
@@ -64,6 +52,9 @@ PARAMETERS:
 `withHttpSettings` configures the settings for a HTTP check. The target must be a URL (http or https).
 
 The `http` object can be created with `check.settings.http.new()`.
+
+Parameters:
+- `httpSettings`: HTTP settings object to override defaults
 
 #### fn check.withHttpStatusCheck
 
@@ -90,6 +81,9 @@ PARAMETERS:
 
 `withLabels` adds custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
 
+Parameters:
+- `labels`: Labels object to add to the check
+
 #### fn check.withProbes
 
 ```jsonnet
@@ -101,3 +95,10 @@ PARAMETERS:
 * **probes** (`array`)
 
 `withProbes` takes a list of probe location IDs where the target will be checked from.
+
+The IDs can be found by using the 'Synthetic Monitoring' data source in Explore.
+
+NOTE: The IDs may be different depending on the stack's location.
+
+Parameters:
+- `probes`: Array of probe IDs to use for monitoring

--- a/grafanaplane/alerting/main.libsonnet
+++ b/grafanaplane/alerting/main.libsonnet
@@ -1,0 +1,6 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#': d.package.newSub('alerting', 'Configure Grafana Managed Alerting (GMA)'),
+  ruleGroup: import './ruleGroup.libsonnet',
+}

--- a/grafanaplane/alerting/ruleGroup.libsonnet
+++ b/grafanaplane/alerting/ruleGroup.libsonnet
@@ -1,0 +1,215 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
+
+local raw = import './zz/main.libsonnet',
+      ruleGroup = raw.alerting.v1alpha1.ruleGroup,
+      forProvider = ruleGroup.spec.parameters.forProvider,
+      rule = forProvider.rule;
+
+{
+  '#': d.package.newSub(
+    'ruleGroup',
+    'Provides functions to set up a ruleGroup.',
+  ),
+
+  '#new': d.func.new(
+    '`new` creates a new rule group resource.',
+    [
+      d.arg('name', d.T.string),
+      d.arg('folderUid', d.T.string),
+    ]
+  ),
+  new(name, folderUid):
+    local uid = xtd.ascii.stringToRFC1123(name);
+    ruleGroup.new(uid)
+    + forProvider.withName(name)
+    + forProvider.withFolderUid(folderUid)
+    + forProvider.withIntervalSeconds(60)
+    + forProvider.withDisableProvenance()
+    + ruleGroup.spec.parameters.withExternalName(std.join(':', [folderUid, name])),
+
+  '#withRules': d.func.new(
+    '`withRules` adds rules to a rule group.',
+    [d.arg('rules', d.T.array)]
+  ),
+  withRules(rules):
+    forProvider.withRuleMixin(rules),
+
+  '#fromPrometheusRuleGroup': d.func.new(
+    |||
+      `fromPrometheusRuleGroup` creates a new rule group from a Prometheus rule group.
+
+      ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+    |||,
+    [
+      d.arg('group', d.T.object),
+      d.arg('folderUid', d.T.string),
+      d.arg('datasourceUid', d.T.string, default='grafanacloud-prom'),
+    ]
+  ),
+  fromPrometheusRuleGroup(group, folderUid, datasourceUid='grafanacloud-prom'):
+    self.new(group.name, folderUid)
+    + self.withRules(
+      std.map(
+        function(rule)
+          if std.objectHas(rule, 'alert')
+          then self.rules.prometheus.fromAlertingRule(rule, datasourceUid)
+          else if std.objectHas(rule, 'record')
+          then self.rules.prometheus.fromRecordingRule(rule, datasourceUid)
+          else error 'rule is neither an alert or a record',
+        group.rules,
+      )
+    ),
+
+  rules: {
+    '#': d.package.newSub(
+      'ruleGroup.rules',
+      |||
+        Provides functions to set up common rules.
+      |||
+    ),
+    prometheus: {
+      '#fromAlertingRule': d.func.new(
+        |||
+          `fromAlertingRule` creates a Grafana Managed Alerting rule from a Prometheus alerting rule
+
+          ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+        |||,
+        [
+          d.arg('alertRule', d.T.object),
+          d.arg('datasourceUid', d.T.string, default='grafanacloud-prom'),
+        ]
+      ),
+      fromAlertingRule(alertRule, datasourceUid='grafanacloud-prom'):
+        rule.withName(alertRule.alert)
+        + rule.withCondition('threshold')
+        + rule.withNoDataState('OK')
+        + rule.withExecErrState('OK')
+        + rule.withFor(alertRule['for'])
+        + (if std.objectHas(alertRule, 'labels')
+           then rule.withLabels(alertRule.labels)
+           else {})
+        + (if std.objectHas(alertRule, 'annotations')
+           then rule.withAnnotations(alertRule.annotations)
+           else {})
+        + (if std.objectHas(alertRule, 'keep_firing_for')
+           then rule.withKeepFiringFor(alertRule.keep_firing_for)
+           else {})
+        + rule.withData([
+          rule.data.withRefId('query')
+          + rule.data.withQueryType('prometheus')
+          + rule.data.withDatasourceUid(datasourceUid)
+          + rule.data.withRelativeTimeRange([
+            rule.data.relativeTimeRange.withFrom(600)
+            + rule.data.relativeTimeRange.withTo(0),
+          ])
+          + rule.data.withModel(
+            std.manifestJson({
+              datasource: {
+                type: 'prometheus',
+                uid: datasourceUid,
+              },
+              expr: alertRule.expr,
+              instant: true,
+              intervalMs: 1000,
+              maxDataPoints: 43200,
+              range: false,
+              refId: 'query',
+            })
+          ),
+
+          rule.data.withRefId('prometheus_math')
+          + rule.data.withQueryType('math')
+          + rule.data.withDatasourceUid('__expr__')
+          + rule.data.withRelativeTimeRange([
+            rule.data.relativeTimeRange.withFrom(0)
+            + rule.data.relativeTimeRange.withTo(0),
+          ])
+          + rule.data.withModel(
+            std.manifestJson({
+              datasource: {
+                name: 'Expression',
+                type: '__expr__',
+                uid: '__expr__',
+              },
+              expression: 'is_number($query) || is_nan($query) || is_inf($query)',
+              intervalMs: 1000,
+              maxDataPoints: 43200,
+              refId: 'prometheus_math',
+              type: 'math',
+            })
+          ),
+
+          rule.data.withRefId('threshold')
+          + rule.data.withQueryType('threshold')
+          + rule.data.withDatasourceUid('__expr__')
+          + rule.data.withRelativeTimeRange([
+            rule.data.relativeTimeRange.withFrom(0)
+            + rule.data.relativeTimeRange.withTo(0),
+          ])
+          + rule.data.withModel(
+            std.manifestJson({
+              datasource: {
+                name: 'Expression',
+                type: '__expr__',
+                uid: '__expr__',
+              },
+              conditions: [{
+                evaluator: {
+                  params: [0],
+                  type: 'gt',
+                },
+              }],
+              intervalMs: 1000,
+              maxDataPoints: 43200,
+              refId: 'threshold',
+              type: 'threshold',
+            })
+          ),
+        ]),
+
+      '#fromRecordingRule': d.func.new(
+        |||
+          `fromRecordingRule` creates a Grafana Managed Alerting rule from a Prometheus recording rule
+
+          ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+        |||,
+        [
+          d.arg('recordingRule', d.T.object),
+          d.arg('datasourceUid', d.T.string, default='grafanacloud-prom'),
+        ]
+      ),
+      fromRecordingRule(recordingRule, datasourceUid='grafanacloud-prom'):
+        rule.withName(recordingRule.record)
+        + (if std.objectHas(recordingRule, 'labels')
+           then rule.withLabels(recordingRule.labels)
+           else {})
+        + rule.record.withFrom('query')
+        + rule.record.withTargetDatasourceUid(datasourceUid)
+        + rule.record.withMetric(recordingRule.record)
+        + rule.withData([
+          rule.data.withRefId('query')
+          + rule.data.withQueryType('prometheus')
+          + rule.data.withDatasourceUid(datasourceUid)
+          + rule.data.withRelativeTimeRange([
+            rule.data.relativeTimeRange.withFrom(600)
+            + rule.data.relativeTimeRange.withTo(0),
+          ])
+          + rule.data.withModel(
+            std.manifestJson({
+              datasource: {
+                type: 'prometheus',
+                uid: datasourceUid,
+              },
+              expr: recordingRule.expr,
+              instant: true,
+              intervalMs: 1000,
+              maxDataPoints: 43200,
+              range: false,
+              refId: 'query',
+            })
+          ),
+        ]),
+    },
+  },
+}

--- a/grafanaplane/main.libsonnet
+++ b/grafanaplane/main.libsonnet
@@ -61,4 +61,5 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   oss: import './oss.libsonnet',
   oncall: import './oncall/main.libsonnet',
   sm: import './sm.libsonnet',
+  alerting: import './alerting/main.libsonnet',
 }

--- a/grafanaplane/sm.libsonnet
+++ b/grafanaplane/sm.libsonnet
@@ -9,19 +9,19 @@ local raw = import './zz/main.libsonnet';
   check: {
     local forProvider = raw.sm.v1alpha1.check.spec.parameters.forProvider,
 
-    // TODO: Probe IDs hardcoded for now, look into ways to get them from API in Crossplane. Observe-only resource for the probes datasource?
-    local fullProbeList = [1, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 756, 757, 853, 854, 855, 856, 867],
-    local shortProbeList = [7, 856, 867],  // Paris, North Virginia, Seoul (all AWS)
-
     '#new': d.func.new(
       |||
-        `new` configures a synthetic monitoring check.
+        `new` creates a new synthetic monitoring check for the betterops Grafana Cloud environment.
 
-        Note: The probe list will match a short list of just three nodes across the globe.
+        Parameters:
+        - `name`: Name of the check
+        - `job`: Job identifier for the check
+        - `url`: Target URL to monitor
       |||,
       [
-        d.argument.new('name', d.T.string),
-        d.argument.new('type', d.T.string),
+        d.arg('name', d.T.string),
+        d.arg('job', d.T.string),
+        d.arg('url', d.T.string),
       ]
     ),
     new(name, job, url):
@@ -29,36 +29,34 @@ local raw = import './zz/main.libsonnet';
       raw.sm.v1alpha1.check.new(slug)
       + forProvider.withJob(job)
       + forProvider.withTarget(url)
-      + forProvider.withProbes(shortProbeList)
-      + forProvider.withEnabled(true)
-      + forProvider.withAlertSensitivity('high')
+      + forProvider.withAlertSensitivity('none')  // used for legacy alerts, use GMA instead
       + forProvider.withBasicMetricsOnly(true)
+      + forProvider.withEnabled(true)
       + forProvider.withFrequency(60000)  // ms
       + forProvider.withTimeout(10000),  // ms
 
     '#withProbes': d.func.new(
       |||
         `withProbes` takes a list of probe location IDs where the target will be checked from.
+
+        The IDs can be found by using the 'Synthetic Monitoring' data source in Explore.
+
+        NOTE: The IDs may be different depending on the stack's location.
+
+        Parameters:
+        - `probes`: Array of probe IDs to use for monitoring
       |||,
       [d.argument.new('probes', d.T.array)],
     ),
     withProbes(probes):
       forProvider.withProbes(probes),
 
-    '#withFullProbeList': d.func.new(
-      |||
-        `withFullProbeList` sets the `probes` array to match the fulll list of probes.
-
-        Note: Probe IDs hardcoded for now.
-      |||,
-      [d.argument.new('probes', d.T.array, fullProbeList)],
-    ),
-    withFullProbeList(probes=fullProbeList):
-      self.withProbes(probes),
-
     '#withLabels': d.func.new(
       |||
         `withLabels` adds custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
+
+        Parameters:
+        - `labels`: Labels object to add to the check
       |||,
       [d.argument.new('labels', d.T.object)]
     ),
@@ -70,6 +68,9 @@ local raw = import './zz/main.libsonnet';
         `withHttpSettings` configures the settings for a HTTP check. The target must be a URL (http or https).
 
         The `http` object can be created with `check.settings.http.new()`.
+
+        Parameters:
+        - `httpSettings`: HTTP settings object to override defaults
       |||,
       [d.argument.new('http', d.T.object)]
     ),


### PR DESCRIPTION
- **feat(grafanaplane/alerting): upstream ruleGroup functions**

GMA rule groups can be generated from Prometheus rule groups, this provides some convenience functions to generate them.

- **fix(grafanaplane/sm): remove probe list and turn off alertSensitivity**

The probe list is different for each region a stack is in, hardcoding values don't make sense at this point.

Alert sensitivity is about the legacy alerts, we'll be promoting GMA alerts instead.