### PR TITLE
fix(gha): satisfy zizmor

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Push xpkg
         run: make push
-        if: ${{ github.ref == 'refs/heads/main' }} && env.REGISTRY != ''
+        if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Zizmor complaining:

```
error[unsound-condition]: unsound conditional expression
  --> ./.github/workflows/push.yaml:36:9
   |
36 |         if: ${{ github.ref == 'refs/heads/main' }} && env.REGISTRY != ''
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ condition always evaluates to true
   |
   = note: audit confidence → High

16 findings (10 ignored, 5 suppressed): 0 informational, 0 low, 0 medium, 1 high
```
