### PR TITLE
chore: pin dependencies and tighten CI permissions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>grafana/grafana-renovate-config//presets/base"],
+  "jsonnet-bundler": {
+    "enabled": true,
+    "fileMatch": ["(^|/)generator/jsonnetfile\\.json$"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["jsonnet-bundler"],
+      "groupName": "jsonnet deps"
+    }
+  ]
+}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,9 @@ jobs:
           version: v0.20.0
 
       - name: setup jrsonnet
-        uses: grafana/shared-workflows/actions/setup-jrsonnet@f619a637e489e8e7749cf4966ee2776e4178a303
+        uses: grafana/shared-workflows/actions/setup-jrsonnet@712fac3f2b51b2a812bf39cf334058346121d67a # setup-jrsonnet/v1.0.2
+        with:
+          version: 0.5.0-pre96-test
 
       - name: Build xpkg
         run: "make -B build"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -47,7 +47,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
 
     steps:
       - name: Extract version

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -41,7 +41,7 @@ jobs:
 
   deploy:
     name: Trigger Argo Workflow Deployment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/generator/jsonnetfile.json
+++ b/generator/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": ""
         }
       },
-      "version": "master"
+      "version": "8e5e345e7933f3e7c19e950710d5c648eb16e1c8"
     },
     {
       "source": {
@@ -17,7 +17,7 @@
           "subdir": ""
         }
       },
-      "version": "master"
+      "version": "349569e180192547cb37cb94b3caea05384a81ff"
     },
     {
       "source": {
@@ -26,7 +26,7 @@
           "subdir": "crdsonnet"
         }
       },
-      "version": "master"
+      "version": "f2f3c043f329edd4dd59ba89128258a59ee3363e"
     },
     {
       "source": {
@@ -35,7 +35,7 @@
           "subdir": ""
         }
       },
-      "version": "duologic/rfc1123"
+      "version": "6b473999814b9eeede12a65177a529428a3a8e74"
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
## Summary

- Pin jsonnet library deps in `generator/jsonnetfile.json` to commit SHAs (from the lockfile), so `jb update` becomes a deliberate, reviewable action rather than a silent pull from upstream `master`.
- Add `.github/renovate.json` extending `grafana/grafana-renovate-config//presets/base` and enabling the `jsonnet-bundler` manager, with the four jsonnet deps grouped into a single PR per refresh.
- Pin `setup-jrsonnet` to `setup-jrsonnet/v1.0.2` (previous SHA was a random monorepo `chore(deps)` commit, not a release) and set the jrsonnet binary version explicitly so the CI toolchain is fully reproducible.
- Align `push.yaml`'s deploy job to `ubuntu-24.04` to match the build job.
- Drop the unused `pull-requests: write` scope from the deploy job — `trigger-argo-workflow`'s own README confirms it only needs `contents: read` and `id-token: write`.

No behavior change for `make build` — the jsonnet lockfile is unchanged and the jrsonnet binary version pinned here matches what CI was already running implicitly via the action's default.


Closes [#594148](https://github.com/grafana/deployment_tools/issues/594148)